### PR TITLE
chore: move to conventional-tools docker hub image

### DIFF
--- a/.github/workflows/ct-commitlint.yml
+++ b/.github/workflows/ct-commitlint.yml
@@ -8,7 +8,7 @@ jobs:
   commits:
     name: Commitlint
     runs-on: ubuntu-latest
-    container: registry.k1.zportal.co.uk/practically-oss/conventional-tools:1.x
+    container: practically/conventional-tools:1.x@sha256:647d6e4b3edfcbac6054b90f74d2c61a022152751b94484d54e13695a9e27377
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ct-release.yml
+++ b/.github/workflows/ct-release.yml
@@ -11,7 +11,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    container: registry.k1.zportal.co.uk/practically-oss/conventional-tools:1.x
+    container: practically/conventional-tools:1.x@sha256:647d6e4b3edfcbac6054b90f74d2c61a022152751b94484d54e13695a9e27377
     env:
       CT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
Move the conventional tools docker image to the one hosted on the docker hub
